### PR TITLE
Service reminder webhook payload

### DIFF
--- a/api-reference/webhooks/service_reminder.mdx
+++ b/api-reference/webhooks/service_reminder.mdx
@@ -39,6 +39,10 @@ The webhook payload is sent as a JSON object with the following structure:
   The unique identifier for the patient in the PIMS, if applicable.
 </ResponseField>
 
+<ResponseField name="notification_rule_name" type="string" required>
+  The name of the notification rule that triggered this webhook.
+</ResponseField>
+
 <ResponseField name="reminders" type="array" required>
   An array of service reminder objects for the services that are due.
 
@@ -68,6 +72,7 @@ The webhook payload is sent as a JSON object with the following structure:
   "remote_client_id": "12345",
   "patient_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
   "remote_patient_id": "67890",
+  "notification_rule_name": "2 weeks before due",
   "reminders": [
     {
       "code": "svc_001",


### PR DESCRIPTION
Add `notification_rule_name` field to the service reminder webhook payload to indicate the triggering notification rule.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d0a20dc-793d-47c2-8493-af4548e7691d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1d0a20dc-793d-47c2-8493-af4548e7691d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

